### PR TITLE
Changes attribute access to index access

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'SQLAlchemy>=0.7.6',
         'python-dateutil',
         'FormEncode>={}'.format(
-            '1.2' if sys.version_info.major == 2 else '1.3.0a1',
+            '1.2' if sys.version_info[0] == 2 else '1.3.0a1',
         ),
         'six',
     ],


### PR DESCRIPTION
In Python 2.6, `sys.version_info` is not a `namedtuple`, so we need to
use an index instead of an attribute access to get the major version
number:

``` sh
$ python2.6 -c "import sys; print(sys.version_info)"
(2, 6, 9, 'final', 0)
$ python2.7 -c "import sys; print(sys.version_info)"
sys.version_info(major=2, minor=7, micro=11, releaselevel='final', serial=0)
$ python3 -c "import sys; print(sys.version_info)"
sys.version_info(major=3, minor=5, micro=1, releaselevel='final', serial=0)
```
